### PR TITLE
Toggl APIのリクエストパラメータに`project_ids`を追加

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -9,7 +9,8 @@ module App
     date = Date.today - 1
 
     toggl = Toggl.new(ENV['TOGGL_API_TOKEN'])
-    summary = toggl.summary('toggl_to_pixela', ENV['TOGGL_WORKSPACE_ID'], date, date)
+    project_ids = ENV['TOGGL_PROJECT_IDS']
+    summary = toggl.summary('toggl_to_pixela', ENV['TOGGL_WORKSPACE_ID'], date, date, project_ids)
 
     exit if summary['total_grand'].nil?
 

--- a/lib/toggl.rb
+++ b/lib/toggl.rb
@@ -9,13 +9,14 @@ class Toggl
     @token = token
   end
 
-  def summary(user_agent, workspace_id, since, until_)
+  def summary(user_agent, workspace_id, since, until_, project_ids)
     url = 'https://api.track.toggl.com/reports/api/v2/summary'
     params = {
       user_agent: user_agent,
       workspace_id: workspace_id,
       since: since,
-      until: until_
+      until: until_,
+      project_ids: project_ids
     }
     headers = { 'Authorization' => "Basic #{Base64.encode64("#{@token}:api_token")}" }
     res = Faraday.get(url, params, headers)


### PR DESCRIPTION
## やったこと

- Toggl APIのリクエストパラメータに`project_ids`を追加

## 申し送り事項

- Githubの環境変数`TOGGL_PROJECT_IDS`に時間を取得したいTogglのプロジェクトIDを登録してください。